### PR TITLE
Fix incorrect class name

### DIFF
--- a/AdminImagesPlugin.php
+++ b/AdminImagesPlugin.php
@@ -12,7 +12,7 @@
  * 
  * @package AdminImages
  */
-class AdminImagesPlugin extends Omeka_plugin_AbstractPlugin
+class AdminImagesPlugin extends Omeka_Plugin_AbstractPlugin
 {
     public function __toString() 
     {


### PR DESCRIPTION
Hi folks,

Installing the latest version of this plugin gives a class not found exception. The base class Omeka_plugin_AbstractPlugin should be written instead as Omeka_Plugin_AbstractPlugin (note the capital 'P' on the first instance of 'Plugin'.

-Adam