### PR TITLE
Fix AdminImages with Omeka 2.8

### DIFF
--- a/controllers/ImageController.php
+++ b/controllers/ImageController.php
@@ -96,23 +96,6 @@ class AdminImages_ImageController extends Omeka_Controller_AbstractActionControl
             $flashMessenger->addMessage($successMessage,'success');
     }
 
-    private function _processNewFile()
-    {
-        require_once(dirname(dirname(__FILE__))."/classes/AdminImages_".$_POST['ingesttype'].".php");
-        
-        $ingesterClass = 'AdminImages_'.$_POST['ingesttype'].'_Ingester';
-        $ingester = new $ingesterClass;
-        $this->_addIngestValidators($ingester);
-        $fileinfo = $_POST['ingesttype']==='Url' ? $_POST['url'] : null;
-        $files = $ingester->itemlessIngest($fileinfo);
-        foreach($files as $file) {
-            $file->item_id=0;
-            $file->save();
-        }
-        return ("File processed successfully");
-    }
-    
-    
     private function _validatePost(){
         if(version_compare(OMEKA_VERSION,'2.2.1') >= 0)
             return true;

--- a/models/AdminImage.php
+++ b/models/AdminImage.php
@@ -122,7 +122,7 @@ class AdminImage extends Omeka_Record_AbstractRecord
         $ingesterClass = 'AdminImages_'.$_POST['ingesttype'].'_Ingester';
         $ingester = new $ingesterClass;
         self::_AddIngestValidators($ingester);
-        $url = $_POST['ingesttype']==='Url' ? $_POST['url'] : null;
+        $url = $_POST['ingesttype']==='Url' ? $_POST['url'] : 'file';
         $files = $ingester->itemlessIngest($url);
         foreach($files as $file) {
             $file->item_id=0;


### PR DESCRIPTION
AdminImages passes "null" as file info to the ingester when uploading. While this was never really intended, it was tolerated by previous versions, while Omeka 2.8 throws an error.

Passing the name of the file input instead fixes the issue.