### PR TITLE
Fix typo in parent class name

### DIFF
--- a/AdminImagesPlugin.php
+++ b/AdminImagesPlugin.php
@@ -12,7 +12,7 @@
  * 
  * @package AdminImages
  */
-class AdminImagesPlugin extends Omeka_plugin_AbstractPlugin
+class AdminImagesPlugin extends Omeka_Plugin_AbstractPlugin
 {
     /**
      * @var array Hooks for the plugin.


### PR DESCRIPTION
This PR should fix #12

The class header extends `Omeka_plugin_AbstractPlugin` which has a typo in its name. It should be `Omeka_Plugin_AbstractPlugin` with a capital `P`.
See https://github.com/omeka/Documentation/blob/master/source/Tutorials/understandingOmeka_Plugin_AbstractPlugin.rst#understanding-omeka_plugin_abstractplugin